### PR TITLE
fix: Update GitHub URL and improve update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,14 @@ Before you begin, ensure you have the following installed on your system:
 For a fast and easy setup, you can run the following command in your terminal. This will download the `setup.sh` script and execute it automatically.
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/your-username/your-repo/main/setup.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Pukerud/LocalLLM/main/setup.sh)"
 ```
-**Note:** Make sure to replace `your-username/your-repo` with the actual path to your GitHub repository.
 
 ### 2. Manual Setup
 
 If you prefer, you can download the `setup.sh` script first and then run it manually.
 ```bash
-wget https://raw.githubusercontent.com/your-username/your-repo/main/setup.sh
+wget https://raw.githubusercontent.com/Pukerud/LocalLLM/main/setup.sh
 chmod +x setup.sh
 ./setup.sh
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -131,20 +131,26 @@ function check_status() { echo ""; echo "\${BLUE}--- Docker Container Status ---
 function update_script() {
     echo ""
     echo "\${BLUE}Checking for updates... \${RESET}"
-    # --- IMPORTANT ---
-    # Replace this URL with the actual raw URL of your setup.sh script on GitHub
-    local update_url="https://raw.githubusercontent.com/your-username/your-repo/main/setup.sh"
+    local update_url="https://raw.githubusercontent.com/Pukerud/LocalLLM/main/setup.sh"
 
     echo "Downloading latest version from \${YELLOW}\$update_url\${RESET}..."
-    # Use /tmp to store the new script temporarily
     local temp_script="/tmp/setup_latest.sh"
-    if curl -sSL -o "\$temp_script" "\$update_url"; then
-        echo "\${GREEN}Download complete. Applying update...\${RESET}"
-        chmod +x "\$temp_script"
-        # Execute the new setup script and exit the manager
-        exec bash "\$temp_script"
+
+    # Use curl with -f to fail silently on server errors (like 404)
+    if curl -fsSL -o "\$temp_script" "\$update_url"; then
+        # Check if the downloaded file is a valid shell script and not a GitHub 404 page
+        if head -n 1 "\$temp_script" | grep -q "^#\!/bin/bash"; then
+            echo "\${GREEN}Download complete. Applying update...\${RESET}"
+            chmod +x "\$temp_script"
+            # Execute the new setup script and exit the manager
+            exec bash "\$temp_script"
+        else
+            echo "\${YELLOW}Downloaded file is not a valid script. The URL may be incorrect.\${RESET}"
+            rm -f "\$temp_script"
+            read -p "Press [Enter] to continue..."
+        fi
     else
-        echo "\${YELLOW}Failed to download the update. Please check the URL or your connection.\${RESET}"
+        echo "\${YELLOW}Failed to download the update. Please check your internet connection or the repository URL.\${RESET}"
         read -p "Press [Enter] to continue..."
     fi
 }


### PR DESCRIPTION
This commit resolves the "404 Not Found" error when using the update feature and makes the script more robust.

The following changes have been made:
- The placeholder GitHub URL in both `setup.sh` (for the update function) and `README.md` (for the one-liner install command) has been replaced with the correct URL provided by the user: `https://raw.githubusercontent.com/Pukerud/LocalLLM/main/setup.sh`.
- The `update_script` function in the generated `llm_manager.sh` has been improved. It now uses `curl -fsSL` to fail silently on server errors and includes a check to verify that the downloaded file is a valid bash script before attempting to execute it. This prevents the script from trying to execute a GitHub 404 error page.

These changes ensure that the update and installation features work correctly and provide better error handling.